### PR TITLE
feat: header components

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -10,5 +10,6 @@ module.exports = {
     },
     `gatsby-transformer-remark`,
     `gatsby-plugin-emotion`,
+    `gatsby-plugin-react-helmet`,
   ],
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -7602,6 +7602,14 @@
         "micromatch": "^3.1.10"
       }
     },
+    "gatsby-plugin-react-helmet": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-react-helmet/-/gatsby-plugin-react-helmet-3.3.1.tgz",
+      "integrity": "sha512-DZ/IWs+zlGL8N3JAcewPJJUPkl1st6/hIWQ3YphKoTK64DUIoMd2wWSJCrC6LiurS7knGHa4pdGyc5clwV1EKA==",
+      "requires": {
+        "@babel/runtime": "^7.9.6"
+      }
+    },
     "gatsby-plugin-typescript": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/gatsby-plugin-typescript/-/gatsby-plugin-typescript-2.4.2.tgz",
@@ -14456,6 +14464,22 @@
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-3.0.0.tgz",
       "integrity": "sha512-XzgvowFrwDo6TWcpJ/WTiarb9UI6lhA4PMzS7n1joK3sHfBBBOQHUc0U4u57D6DWO9vHv6lVSWx2Q/Ymfyv4hw=="
     },
+    "react-fast-compare": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-2.0.4.tgz",
+      "integrity": "sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw=="
+    },
+    "react-helmet": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/react-helmet/-/react-helmet-6.0.0.tgz",
+      "integrity": "sha512-My6S4sa0uHN/IuVUn0HFmasW5xj9clTkB9qmMngscVycQ5vVG51Qp44BEvLJ4lixupTwDlU9qX1/sCrMN4AEPg==",
+      "requires": {
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.7.2",
+        "react-fast-compare": "^2.0.4",
+        "react-side-effect": "^2.1.0"
+      }
+    },
     "react-hot-loader": {
       "version": "4.12.21",
       "resolved": "https://registry.npmjs.org/react-hot-loader/-/react-hot-loader-4.12.21.tgz",
@@ -14504,6 +14528,11 @@
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.7.2.tgz",
       "integrity": "sha512-u5l7fhAJXecWUJzVxzMRU2Zvw8m4QmDNHlTrT5uo3KBlYBhmChd7syAakBoay1yIiVhx/8Fi7a6v6kQZfsw81Q=="
+    },
+    "react-side-effect": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/react-side-effect/-/react-side-effect-2.1.0.tgz",
+      "integrity": "sha512-IgmcegOSi5SNX+2Snh1vqmF0Vg/CbkycU9XZbOHJlZ6kMzTmi3yc254oB1WCkgA7OQtIAoLmcSFuHTc/tlcqXg=="
     },
     "read": {
       "version": "1.0.7",

--- a/package.json
+++ b/package.json
@@ -26,11 +26,13 @@
     "emotion-theming": "^10.0.27",
     "gatsby": "^2.21.33",
     "gatsby-plugin-emotion": "^4.3.1",
+    "gatsby-plugin-react-helmet": "^3.3.1",
     "gatsby-source-filesystem": "^2.3.3",
     "gatsby-transformer-remark": "^2.8.8",
     "prop-types": "^15.7.2",
     "react": "^16.13.1",
-    "react-dom": "^16.13.1"
+    "react-dom": "^16.13.1",
+    "react-helmet": "^6.0.0"
   },
   "devDependencies": {
     "@commitlint/cli": "^8.3.5",

--- a/src/components/Header/index.jsx
+++ b/src/components/Header/index.jsx
@@ -1,10 +1,20 @@
 import React from 'react';
 
+import SiteName from '../SiteName';
+import Nav from '../Nav';
+import NavItem from '../NavItem';
 import { HeaderContainer, HeaderInner } from './style';
 
 const Header = () => (
   <HeaderContainer>
-    <HeaderInner>Header</HeaderInner>
+    <HeaderInner>
+      <SiteName to="/">Olly Nevard</SiteName>
+      <Nav>
+        <NavItem to="/articles">Articles</NavItem>
+        <NavItem to="/projects">Projects</NavItem>
+        <NavItem to="/about">About</NavItem>
+      </Nav>
+    </HeaderInner>
   </HeaderContainer>
 );
 

--- a/src/components/Header/style.jsx
+++ b/src/components/Header/style.jsx
@@ -1,12 +1,11 @@
 import styled from '@emotion/styled';
 
-export const HeaderContainer = styled.header`
-  display: flex;
-`;
+export const HeaderContainer = styled.header``;
 
 export const HeaderInner = styled.div`
+  align-items: center;
+  display: flex;
+  justify-content: space-between;
   margin: 0 auto;
-  max-width: 960px;
-  padding: 20px;
-  width: 100%;
+  padding: 20px 30px;
 `;

--- a/src/components/Layout/index.jsx
+++ b/src/components/Layout/index.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { ThemeProvider } from 'emotion-theming';
+import { Helmet } from 'react-helmet';
 
 import theme from '../../theme';
 import Header from '../Header';
@@ -9,6 +10,9 @@ import { GlobalStyles, LayoutContainer, Main } from './style';
 
 const Layout = ({ children }) => (
   <ThemeProvider theme={theme}>
+    <Helmet>
+      <link rel="stylesheet" href="https://use.typekit.net/ugi8yzu.css" />
+    </Helmet>
     <LayoutContainer>
       <GlobalStyles />
       <Header />

--- a/src/components/Layout/style.jsx
+++ b/src/components/Layout/style.jsx
@@ -16,8 +16,13 @@ export const GlobalStyles = () => {
         body {
           background-color: ${theme.colors.background};
           color: ${theme.colors.text};
+          font-family: ${theme.fonts.serif};
+          font-size: 20px;
+          font-variant-ligatures: discretionary-ligatures;
+          font-weight: 400;
           height: 100%;
           margin: 0;
+          -webkit-font-smoothing: antialiased;
         }
 
         #___gatsby,
@@ -36,7 +41,7 @@ export const LayoutContainer = styled.div`
 `;
 
 export const Main = styled.main`
-  height: 100%;
+  flex-grow: 1;
   margin: 0 auto;
   max-width: 960px;
   padding: 20px;

--- a/src/components/Nav/index.jsx
+++ b/src/components/Nav/index.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { NavContainer, NavList } from './style';
+
+const Nav = ({ children }) => (
+  <NavContainer>
+    <NavList>{children}</NavList>
+  </NavContainer>
+);
+
+Nav.propTypes = {
+  children: PropTypes.node.isRequired,
+};
+
+export default Nav;

--- a/src/components/Nav/style.jsx
+++ b/src/components/Nav/style.jsx
@@ -1,0 +1,9 @@
+import styled from '@emotion/styled';
+
+export const NavContainer = styled.nav``;
+
+export const NavList = styled.ul`
+  display: flex;
+  margin: 0;
+  padding: 0;
+`;

--- a/src/components/NavItem/index.jsx
+++ b/src/components/NavItem/index.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { NavItemContainer, NavItemLink } from './style';
+
+const NavItem = ({ to, children }) => (
+  <NavItemContainer>
+    <NavItemLink to={to}>{children}</NavItemLink>
+  </NavItemContainer>
+);
+
+NavItem.propTypes = {
+  to: PropTypes.string.isRequired,
+  children: PropTypes.node.isRequired,
+};
+
+export default NavItem;

--- a/src/components/NavItem/style.jsx
+++ b/src/components/NavItem/style.jsx
@@ -1,0 +1,20 @@
+import styled from '@emotion/styled';
+import { Link } from 'gatsby';
+
+export const NavItemContainer = styled.li`
+  font-family: ${({ theme }) => theme.fonts.sans};
+  font-size: 16px;
+  font-weight: 600;
+  list-style: none;
+  margin-right: 30px;
+  text-transform: uppercase;
+
+  &:last-child {
+    margin-right: 0;
+  }
+`;
+
+export const NavItemLink = styled(Link)`
+  color: inherit;
+  text-decoration: none;
+`;

--- a/src/components/SiteName/index.jsx
+++ b/src/components/SiteName/index.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { SiteNameContainer, SiteNameLink } from './style';
+
+const SiteName = ({ to, children }) => (
+  <SiteNameContainer>
+    <SiteNameLink to={to}>{children}</SiteNameLink>
+  </SiteNameContainer>
+);
+
+SiteName.propTypes = {
+  children: PropTypes.node.isRequired,
+  to: PropTypes.string.isRequired,
+};
+
+export default SiteName;

--- a/src/components/SiteName/style.jsx
+++ b/src/components/SiteName/style.jsx
@@ -1,0 +1,15 @@
+import styled from '@emotion/styled';
+import { Link } from 'gatsby';
+
+export const SiteNameContainer = styled.h1`
+  font-family: ${({ theme }) => theme.fonts.sans};
+  font-size: 16px;
+  font-weight: 600;
+  margin: 0;
+  text-transform: uppercase;
+`;
+
+export const SiteNameLink = styled(Link)`
+  color: inherit;
+  text-decoration: none;
+`;

--- a/src/theme.js
+++ b/src/theme.js
@@ -3,4 +3,8 @@ export default {
     background: '#fdf9f3',
     text: '#2c292d',
   },
+  fonts: {
+    serif: 'adobe-garamond-pro, serif',
+    sans: 'noto-sans-display, sans-serif',
+  },
 };


### PR DESCRIPTION
Add react-helmet plugin to manage `<head>`, used initially for adding Typekit CSS.

Add components for SiteName, Nav and NavItem.

Style header.

Closes #40 